### PR TITLE
Fix typo

### DIFF
--- a/docs/dedicated-hardware.md
+++ b/docs/dedicated-hardware.md
@@ -1,6 +1,6 @@
 # Setting up the system on dedicated hardware
 
-The recommended hardware for setting up this repository on a dedicated machin is Odroid H2 with at least 1TB NVMe SSD and 8GB of RAM.
+The recommended hardware for setting up this repository on a dedicated machine is Odroid H2 with at least 1TB NVMe SSD and 8GB of RAM.
 We recommend more RAM to leave a room for future expansion.
 It is also recommended to use a fan - it can get very hot otherwise!
 The fan is very quiet even when the chain syncs - you can't hear it until your head is very close.


### PR DESCRIPTION
Fixing missing `e`. 
Also I would consider rewriting this as:
- General approach on dedicated HW
- Using SBC - Odroid H2 as recommended
By brief search, it seems Odroid H2 is mostly out of stock so docs could offer more suggestions.