### PR TITLE
Set bitcoind nosettings enabled by default

### DIFF
--- a/pkg_specs/bitcoin-@variant.sps
+++ b/pkg_specs/bitcoin-@variant.sps
@@ -89,6 +89,18 @@ try_overwrite_default = "mem_avail=\"`grep MemTotal /proc/meminfo | awk '{{print
 priority = "medium"
 summary = "Size of database cache in MB"
 
+[config."bitcoin.conf".ivars.no_settings]
+type = "bool"
+default = "true"
+priority = "low"
+summary = "Disable dynamic settings"
+store = false
+
+[config."bitcoin.conf".hvars.nosettings]
+type = "string"
+script = "if [ \"${{CONFIG[\"bitcoin-{variant}/no_settings\"]}}\" = true ]; then echo -n 1; fi"
+ignore_empty = true
+
 [config."bitcoin.conf".hvars.rpccookiefile]
 type = "string"
 template = "/var/run/bitcoin-{variant}/cookie"


### PR DESCRIPTION
Resolve #193 

According to [bitcoind documentation](https://github.com/bitcoin/bitcoin/blob/master/doc/files.md), `settings.json` is under the datadir which

> Read-write settings set through GUI or RPC interfaces, augmenting manual settings from `bitcoin.conf`. File is created  automatically if read-write settings storage is not disabled with `-nosettings` option.

As you can see with this PR, the `settings.json` no longer exists by default in the datadir, which can indicate the correctness of this PR resolving #193 

![](https://user-images.githubusercontent.com/43995067/160528113-da9db046-a8c2-4e3d-8ea1-2b0cbf9d2edb.png)

If change into false:

![](https://user-images.githubusercontent.com/43995067/160528195-445915b3-671c-4926-a6d9-e78cee0f3fd9.png)

Signed-off-by: Hollow Man <hollowman@opensuse.org>