### PR TITLE
[SoB] Add GitHub workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,139 @@
+name: CADR CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  USER_NAME: user
+  BUILD_DIR: /home/user/cadr-build
+  IMAGE_NAME: cadr/cadr
+  CONTAINER_NAME: cadr
+  CI_SCRIPT: ci_build.sh
+  PODMAN_CMD: "sudo -E XDG_RUNTIME_DIR= podman"
+  SPAWN_CONTAINER: "$PODMAN_CMD run --tmpfs /tmp --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged --systemd=true -d -v $PWD:$BUILD_DIR --name=$CONTAINER_NAME $IMAGE_NAME"
+  EXECUTE_CMD: "$PODMAN_CMD exec -u $USER_NAME -i $CONTAINER_NAME"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup CI Build Script
+        run: |
+          tee -a $CI_SCRIPT <<EOF
+          #!/bin/bash
+          set -ex
+          sudo apt-get update
+          sudo chown -R $USER_NAME $BUILD_DIR
+          cd $BUILD_DIR
+          MKCMD="make BUILD_DIR=${BUILD_DIR}/build"
+          \$MKCMD build-dep
+          \$MKCMD all
+          EOF
+          chmod +x $CI_SCRIPT
+      - name: Build CADR Running Environment Image
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade podman
+          $PODMAN_CMD build -t $IMAGE_NAME .
+          $PODMAN_CMD save $IMAGE_NAME > CADR_image.tar
+      - name: Upload the Running Environment Image to Artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: CADR_image
+          path: CADR_image.tar
+      - name: Spawn Podman Container to Prepare Running Environment
+        run: |
+          eval $SPAWN_CONTAINER
+      - name: Build CADR
+        run: |
+          eval $EXECUTE_CMD ${BUILD_DIR}/$CI_SCRIPT
+      - name: Upload Debian Packages Just Built to Artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: CADR_debs
+          path: build/*.deb
+      - name: Check SHA256
+        if: ${{ always() }}
+        run: |
+          sudo chown -R $USER build
+          cd build
+          for file in *.deb
+          do
+            sha256sum $file > ${file}.sha256sum
+            cat $file.sha256sum
+          done
+      - name: Upload SHA256 of Debian Packages Just Built to Artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: CADR_debs_sha256sum
+          path: build/*.deb.sha256sum
+      - name: Fix the Dir Permission for Post checkout
+        if: ${{ always() }}
+        run: |
+          sudo chown -R $USER $PWD
+
+  test:
+    needs: build
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ["bitcoind", "bitcoin-mainnet", "bitcoin-regtest",
+          "bitcoin-pruned-mainnet", "bitcoin-fullchain-mainnet", "bitcoin-fullchain-regtest",
+          "bitcoin-txindex-mainnet", "bitcoin-zmq-mainnet", "bitcoin-zmq-regtest",
+          "bitcoin-rpc-proxy", "bitcoin-rpc-proxy-mainnet", "bitcoin-rpc-proxy-regtest",
+          "bitcoin-timechain-mainnet", "electrs", "electrs-mainnet", "electrs-regtest",
+          "btcpayserver", "btcpayserver-system-mainnet", "btcpayserver-system-regtest",
+          "lnd", "lnd-system-mainnet", "lnd-system-regtest","lnd-unlocker-system-mainnet",
+          "lnd-unlocker-system-mainnet", "ridetheln", "ridetheln-system",
+          "ridetheln-lnd-system-mainnet", "ridetheln-lnd-system-regtest", "selfhost",
+          "selfhost-nginx", "selfhost-onion", "selfhost-clearnet",
+          "selfhost-clearnet-certbot", "tor-hs-patch-config", "thunderhub",
+          "thunderhub-system-mainnet", "thunderhub-system-regtest", "btc-rpc-explorer-mainnet",
+          "lndconnect", "selfhost-dashboard-bin", "selfhost-dashboard", "btc-transmuter",
+          "btc-transmuter-system-mainnet", "btc-transmuter-system-regtest"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Test Prefix
+        run: |
+          echo "TEST_PREFIX=sudo chown -R $USER_NAME $BUILD_DIR && cd $BUILD_DIR && make BUILD_DIR=$BUILD_DIR/build" >> $GITHUB_ENV
+      - name: Prepare Podman Container Running Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade podman
+      - name: Download Pre-built Container Image
+        uses: actions/download-artifact@v3
+        with:
+          name: CADR_image
+          path: .
+      - name: Load Running Environment Image
+        run: |
+          $PODMAN_CMD load < CADR_image.tar
+          mkdir build
+      - name: Download Pre-built Debian Packages
+        uses: actions/download-artifact@v3
+        with:
+          name: CADR_debs
+          path: build
+      - name: Test CADR Basic
+        run: |
+          eval $SPAWN_CONTAINER
+          eval $EXECUTE_CMD bash -c "\"$TEST_PREFIX test-here-basic-${{ matrix.package }}\""
+          $PODMAN_CMD rm -f $CONTAINER_NAME
+      - name: Test CADR Upgrade
+        run: |
+          eval $SPAWN_CONTAINER
+          eval $EXECUTE_CMD bash -c "\"$TEST_PREFIX SPLIT_STRATEGY=upgrade test-here-upgrade-${{ matrix.package }}\""
+      - name: Fix the Dir Permission for Post checkout
+        if: ${{ always() }}
+        run: |
+          sudo chown -R $USER $PWD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:buster
+
+LABEL repository="https://github.com/debian-cryptoanarchy/cryptoanarchy-deb-repo-builder"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo 'APT::Get::Assume-Yes "true";' >> /etc/apt/apt.conf.d/90assumeyes
+
+COPY tests/data/microsoft_key.gpg /tmp/
+COPY tests/data/microsoft_apt.list /tmp/
+
+RUN apt-get update && apt-get dist-upgrade && \
+    apt-get install apt-utils && \
+    apt-get install wget cargo npm git apt-transport-https \
+    ruby-mustache dirmngr sudo libvips-dev ca-certificates gpg \
+    systemd systemd-sysv net-tools netcat xxd && \
+    update-ca-certificates && \
+    mv /tmp/microsoft_apt.list /etc/apt/sources.list.d/microsoft.list && \
+    apt-key add < /tmp/microsoft_key.gpg && \
+    apt-get update && \
+    cargo install --root /usr/local --locked --git https://github.com/Kixunil/debcrafter && \
+    cargo install --root /usr/local --locked cfg_me && \
+    apt-get autoremove && apt-get clean && \
+    rm -rf /root/.cargo \
+    /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+    /lib/systemd/system/systemd-update-utmp* \
+    /usr/sbin/policy-rc.d
+
+RUN adduser --disabled-password user && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER user
+RUN mkdir -p ~/.gnupg/private-keys-v1.d && \
+    chmod 700 ~/.gnupg/private-keys-v1.d
+USER root
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
This GitHub Actions CI can be triggered manually, or by sending PRs as well as pushing directly to the master branch. The CI is divided into 2 jobs:
- First one is the build job. It builds the running podman environment image, upload the image to Artifacts for reuse. Then with the podman environment, builds the CADR packages, and then uploads the built Debian packages as well as their sha256 sum to Artifacts.
- Second one is the test job. It runs when the build job finishes. the testing jobs are run in parallel for each package. The test job first downloads the built images and packages Artifacts uploaded in the build job, then use `make test-here-basic-%` and `make test-here-upgrade-%`(% for package name) to run tests.

Signed-off-by: Hollow Man <hollowman@opensuse.org>