### PR TITLE
Remove bc dependency for overriding dbcache

### DIFF
--- a/pkg_specs/bitcoin-@variant.sps
+++ b/pkg_specs/bitcoin-@variant.sps
@@ -85,7 +85,18 @@ summary = "Bitcoin RPC port"
 type = "uint"
 default = "450"
 # sets dbcache to the closest power of two to half of the memory but not greater than 4096
-try_overwrite_default = "mem_avail=\"`grep MemTotal /proc/meminfo | awk '{{print $2}}'`\" && echo \"if($mem_avail < 8192000) {{ x=l($mem_avail/2000)/l(2); scale=0; 2^((x+0.5)/1) }} else {{ 4096 }}\" | bc -l"
+try_overwrite_default = """
+mem_avail=`grep MemTotal /proc/meminfo | awk '{{print $2}}'` &&
+if [ $mem_avail -lt 1024000 ]; then
+    echo -n 450;
+elif [ $mem_avail -lt 2048000 ]; then
+    echo -n 512;
+elif [ $mem_avail -lt 4096000 ]; then
+    echo -n 1024;
+elif [ $mem_avail -lt 8192000 ]; then
+    echo -n 2048;
+else echo -n 4096; fi
+"""
 priority = "medium"
 summary = "Size of database cache in MB"
 

--- a/tests/per-package/bitcoin-regtest/after_install.sh
+++ b/tests/per-package/bitcoin-regtest/after_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if sudo grep '^dbcache=450$' /etc/bitcoin-regtest/bitcoin.conf;
+if sudo grep '^dbcache=450$' /etc/bitcoin-regtest/bitcoin.conf && 
+   [ `grep MemTotal /proc/meminfo | awk '{{print $2}}'` -ge 1024000 ];
 then
 	echo "Failed to override dbcache" >&2
 	exit 1


### PR DESCRIPTION
Resolve #199 
Also update the test so that if RAM < 1024, the default dbcache will be OK.

Tested on my Machine with RAM slightly less than 4GB:

![](https://user-images.githubusercontent.com/43995067/160542155-465bf97a-f8bc-4f52-a7f1-af0e1b690e9c.png)

Signed-off-by: Hollow Man <hollowman@opensuse.org>