### PR TITLE
Try more times to test connecting to electrs-regtest

### DIFF
--- a/tests/per-package/electrs-regtest/after_install.sh
+++ b/tests/per-package/electrs-regtest/after_install.sh
@@ -14,4 +14,12 @@ sleep 10
 electrs_port="`grep '^ *electrum_rpc_addr *= *' "/etc/electrs-$bitcoin_network/conf.d/interface.toml"`"
 electrs_port="`echo "$electrs_port" | sed 's/^ *electrum_rpc_addr *= *"[^:"]*:\([^"]*\)" *$/\1/'`"
 
-echo '{ "id" : 0, "method": "server.version", "params": ["1.9.5", "0.10"] }' | nc -q 10 127.0.0.1 "$electrs_port" >&2
+for i in {0..3}; do
+	if echo '{ "id" : 0, "method": "server.version", "params": ["1.9.5", "0.10"] }' | nc -q 10 127.0.0.1 "$electrs_port" >&2; then
+		break
+	elif [ $i -eq 3 ]; then
+		echo "Failed to connect to electrs-regtest"
+		exit 1
+	fi
+	sleep 2
+done


### PR DESCRIPTION
This can fix the error for https://github.com/HollowMan6/build-cryptoanarchy-deb-repo-builder/runs/5713299561?check_suite_focus=true as electrs won't be instantly available when just started up.

Signed-off-by: Hollow Man <hollowman@opensuse.org>