### PR TITLE
Fix tests for bitcoin-regtest after setting bitcoind nosettings enabled

### DIFF
--- a/tests/per-package/bitcoin-regtest/after_install.sh
+++ b/tests/per-package/bitcoin-regtest/after_install.sh
@@ -18,7 +18,7 @@ then
 	exit 1
 fi
 
-if sudo test -e "/var/lib/bitcoin-regtest/regtest/wallets/test_wallet";
+if sudo test -e "/var/lib/bitcoin-regtest/regtest/test_wallet";
 then
 	wget -O - --post-data='{"jsonrpc": "1.0", "id":"curltest0", "method": "loadwallet", "params": ["test_wallet"] }' --header 'content-type: text/plain;' --header 'Authorization: Basic '"`sudo cat /var/run/bitcoin-regtest/cookie | base64 | tr -d '\n'`" "http://127.0.0.1:`sudo grep '^rpcport=' /etc/bitcoin-regtest/bitcoin.conf | sed 's/^rpcport=//' | tr -d '\n'`"
 else


### PR DESCRIPTION
Hi @Kixunil , I have figured https://github.com/debian-cryptoanarchy/cryptoanarchy-deb-repo-builder/pull/198#issuecomment-1209132411 out! This PR fixes the error for https://github.com/HollowMan6/build-cryptoanarchy-deb-repo-builder/actions/runs/2822702454

```log
Generating 150 blocks to address 
--2022-05-21 16:08:34--  http://127.0.0.1:18442/
Connecting to 127.0.0.1:18442... connected.
HTTP request sent, awaiting response... 500 Internal Server Error
2022-05-21 16:08:34 ERROR 500: Internal Server Error.
```

As you can see from the logs with nosettings disabled and enabled, the wallet path changes (now `Using wallet directory /var/lib/bitcoin-regtest/regtest`):
[before_debug.log](https://github.com/debian-cryptoanarchy/cryptoanarchy-deb-repo-builder/files/9292780/before_debug.log)
[after_debug.log](https://github.com/debian-cryptoanarchy/cryptoanarchy-deb-repo-builder/files/9292782/after_debug.log)

With this PR, now the CI also works OK: https://github.com/HollowMan6/build-cryptoanarchy-deb-repo-builder/runs/7750083297?check_suite_focus=true

Signed-off-by: Hollow Man <hollowman@opensuse.org>