### PR TITLE
Update BTCPay and replace certthumbprint

### DIFF
--- a/build_rules/btcpayserver.yaml
+++ b/build_rules/btcpayserver.yaml
@@ -4,7 +4,7 @@ source_name: btcpayserver
 
 clone_url: https://github.com/btcpayserver/btcpayserver
 git_tag: v$(BTCPAYSERVER_VERSION)
-fingerprint: 836C08CF3F523BB7A8CB8ECF8E5530D9D1C93097
+fingerprint: AB4CFA9895ACA0DBE27F6B346618763EF09186FE
 verify_commit: true
 build_system: dotnet
 dotnet_csproj: BTCPayServer/BTCPayServer.csproj

--- a/pkg_specs/btcpayserver-lnp-system-@variant.sps
+++ b/pkg_specs/btcpayserver-lnp-system-@variant.sps
@@ -19,11 +19,6 @@ store = false
 [config."conf.d/lnd.conf".evars."lnd-system-@variant".tlscertpath]
 store = false
 
-[config."conf.d/lnd.conf".hvars."certthumbprint"]
-type = "string"
-store = false
-script = "openssl x509 -noout -fingerprint -sha256 -inform pem -in ${{CONFIG[\"lnd-system-{variant}/tlscertpath\"]}} | sed 's/^.*=//' | tr -d ':'"
-
 [config."conf.d/lnd.conf".hvars."btc.lightning"]
 type = "string"
-template = "type=lnd-rest;server=https://127.0.0.1:{lnd-system-@variant/rest_port}/;macaroonfilepath=/var/lib/lnd-system-{variant}/invoice/invoice+readonly.macaroon;certthumbprint={/certthumbprint}"
+template = "type=lnd-rest;server=https://127.0.0.1:{lnd-system-@variant/rest_port}/;macaroonfilepath=/var/lib/lnd-system-{variant}/invoice/invoice+readonly.macaroon;certfilepath=/var/lib/lnd-system-{variant}/public/tls.cert"

--- a/pkg_specs/btcpayserver.changelog
+++ b/pkg_specs/btcpayserver.changelog
@@ -1,3 +1,10 @@
+btcpayserver (1.6.11-1) buster; urgency=high
+
+  * Updated upstream version
+  * Use certfilepath instead of certhumbprint to keep cert in sync
+
+ -- Martin Habovstiak <martin.habovstiak@gmail.com>  Mon, 26 Sep 2022 21:01:19 +0100
+
 btcpayserver (1.6.7-1) buster; urgency=high
 
   * Updated upstream version


### PR DESCRIPTION
The new version of BTCPayServer supports specifying cert file path directly bypassing the need to sync configuration.