### PR TITLE
Update LND to 0.18.1

### DIFF
--- a/build_rules/lnd.pin
+++ b/build_rules/lnd.pin
@@ -1,1 +1,1 @@
-9ac3607b2421de4939e41b87e640a7f65682333813f2cd7c6e6168c89d905b69  lnd-linux-amd64-v0.17.0-beta.tar.gz
+468ee28efa13d844b6937a4dc3907d1d58ae93b7ae6dd8c54460cab76dc15c35  lnd-linux-amd64-v0.18.1-beta.tar.gz

--- a/build_rules/lnd.yaml
+++ b/build_rules/lnd.yaml
@@ -15,4 +15,6 @@ shasums:
         url: https://github.com/lightningnetwork/lnd/releases/download/v$(LND_VERSION)-beta/manifest-v$(LND_VERSION)-beta.txt
         detached_sig: https://github.com/lightningnetwork/lnd/releases/download/v$(LND_VERSION)-beta/manifest-guggero-v$(LND_VERSION)-beta.sig
 
+run: ./lncli generatemanpage
+
 build_system: none

--- a/buildsystems/none/debian-makefile-template
+++ b/buildsystems/none/debian-makefile-template
@@ -7,3 +7,6 @@ install:
 	mkdir -p $(DESTDIR){{{copy_all}}}
 	cp -at $(DESTDIR){{{copy_all}}} $(filter-out debian Dockerfile% %.Dockerfile docker README.md .% LICENSE% CONTRIBUTING% docs {{copy_exclude_files}}, $(wildcard *))
 {{/copy_all}}
+{{#run}}
+	{{{run}}}
+{{/run}}

--- a/pkg_specs/lncli.sps
+++ b/pkg_specs/lncli.sps
@@ -3,6 +3,7 @@ architecture = "any"
 summary = "Lightnning Network Daemon CLI"
 suggests = ["lnd-system-mainnet | lnd-system-regtest"]
 add_files = ["lncli /usr/lib/lncli"]
+add_manpages = ["lncli.1"]
 import_files = [["../lnd/xlncli", "/usr/share/lncli/xlncli"]]
 long_doc = """lncli is a tool used for managing lnd from the command line. This package
 also contains a wrapper used to connect to the system-wide LND by default.

--- a/pkg_specs/lnd.changelog
+++ b/pkg_specs/lnd.changelog
@@ -1,3 +1,9 @@
+lnd (0.18.1-1) buster; urgency=medium
+
+  * Updated upstream version
+  * Added man pages
+
+ -- Martin Habovstiak <martin.habovstiak@gmail.com>  Thu, 04 Jul 2024 18:10:12 +0000
 lnd (0.17.0-1) buster; urgency=medium
 
   * Updated upstream version

--- a/pkg_specs/lnd.sps
+++ b/pkg_specs/lnd.sps
@@ -4,6 +4,7 @@ summary = "Lightnning Network Daemon"
 recommends = ["bitcoin-mainnet | bitcoin-regtest, lnd-system-mainnet | bitcoin-regtest, lnd-system-regtest | bitcoin-mainnet, lnd-system-both | lnd-system-mainnet | lnd-system-regtest"]
 suggests = ["lncli"]
 add_files = ["lnd /usr/bin"]
+add_manpages = ["lnd.1"]
 import_files = [
 	["../lnd/bash_lib.sh", "/usr/share/lnd/lib/bash.sh"],
 	["../lnd/get_external_addr.sh", "/usr/share/lnd/get_external_addr.sh"]


### PR DESCRIPTION
The new version of LND also supports generating manpages. We add a quick-and-dirty way to do that. It doesn't support cross compilation but we don't do that now anyway. It could be relatively easily added by downloading the HOST archive and using that to generate.