### PR TITLE
`bitcoind` conflict with `bitcoin-timechain-*`

### DIFF
--- a/pkg_specs/bitcoin.changelog
+++ b/pkg_specs/bitcoin.changelog
@@ -1,3 +1,8 @@
+bitcoin (27.1-2) buster; urgency=medium
+
+  * Improve dependency specification
+
+ -- Martin Habovstiak <martin.habovstiak@gmail.com>  Tue, 30 Jul 2024 08:56:53 +0000
 bitcoin (27.1-1) buster; urgency=medium
 
   * Updated upstream version

--- a/pkg_specs/bitcoind.sps
+++ b/pkg_specs/bitcoind.sps
@@ -1,7 +1,7 @@
 name = "bitcoind"
 architecture = "any"
 summary = "Bitcoin full node daemon binaries"
-conflicts = ["nbxplorer (<< 2.1.47)", "python3-lnpbp-testkit (<< 0.1.4)", "bitcoin-rpc-proxy-mainnet (<< 0.4.0-1)", "bitcoin-rpc-proxy-regtest (<< 0.4.0-1)"]
+conflicts = ["nbxplorer (<< 2.1.47)", "python3-lnpbp-testkit (<< 0.1.4)", "bitcoin-rpc-proxy-mainnet (<< 0.4.0-1)", "bitcoin-rpc-proxy-regtest (<< 0.4.0-1)", "bitcoin-timechain-mainnet (<< 0.4.0-1)", "bitcoin-timechain-regtest (<< 0.4.0-1)"]
 recommends = ["bitcoin-mainnet | bitcoin-regtest"]
 suggests = ["bitcoin-cli"]
 add_files = [


### PR DESCRIPTION
`bitcoind` versions >= 23.0 change RPC by moving things from `getblockchaininfo` to `getdeploymentinfo`. Services that need to call the new RPC would get broken by this. There's no clean way to fix this so this change at least adds the timechain packages to `bitcoind`'s conflicts to force them to upgrade together.