### PR TITLE
Ignore update_packages.py errors in package-update-check.yml

### DIFF
--- a/.github/workflows/package-update-check.yml
+++ b/.github/workflows/package-update-check.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Run update packages script
         id: update-check
         run: |
-          python tools/update_packages.py
+          # Ignore errors because while some packages may fail to update, others may succeed and we want successes to still pass
+          python tools/update_packages.py || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
Sometimes there are multiple package updates and some may fail while other may not. We want the successful ones to continue, so we need to ignore the error returned by the script.